### PR TITLE
Work in progress on TenDRA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 MAINTAINER Matt Godbolt <matt@godbolt.org>
 
 ARG DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386
 RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
     apt install -y -q \
+    bmake \
     curl \
-    make \
     gcc \
+    gcc-multilib \
     git \
+    libc6-dev-i386 \
+    libc6-dev:i386 \
+    linux-libc-dev \
+    make \
     s3cmd \
     xz-utils
 

--- a/build/buildTenDRA.sh
+++ b/build/buildTenDRA.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+VERSION=$1
+if echo ${VERSION} | grep 'trunk'; then
+    VERSION=trunk-$(date +%Y%m%d)
+    BRANCH=main
+else
+    BRANCH=V${VERSION}
+fi
+
+OUTPUT=/root/tendra-${VERSION}.tar.xz
+S3OUTPUT=""
+if echo $2 | grep s3://; then
+    S3OUTPUT=$2
+else
+    OUTPUT=${2-/root/tendra-${VERSION}.tar.xz}
+fi
+
+PREFIX=$(pwd)/prefix
+DIR=$(pwd)/tendra
+git clone --depth 1 -b ${BRANCH} https://github.com/tendra/tendra.git ${DIR}
+
+# no -j (currently breaks)
+pmake -C ${DIR} TARGETARCH=x32_64
+pmake -C ${DIR} TARGETARCH=x32_64 bootstrap-rebuild
+# todo after this point...
+pmake -C ${DIR} PREFIX=${PREFIX} install
+
+export XZ_DEFAULTS="-T 0"
+tar Jcf ${OUTPUT} --transform "s,^./,./tendra-${VERSION}/," -C ${PREFIX} .
+
+if [[ ! -z "${S3OUTPUT}" ]]; then
+    s3cmd put --rr ${OUTPUT} ${S3OUTPUT}
+fi

--- a/build/buildTenDRA.sh
+++ b/build/buildTenDRA.sh
@@ -18,18 +18,20 @@ else
     OUTPUT=${2-/root/tendra-${VERSION}.tar.xz}
 fi
 
-PREFIX=$(pwd)/prefix
+PREFIX_BOOTSTRAP=$(pwd)/prefix/bootstrap
+PREFIX_REBUILD=$(pwd)/prefix/rebuild
+
 DIR=$(pwd)/tendra
 git clone --depth 1 -b ${BRANCH} https://github.com/tendra/tendra.git ${DIR}
 
 # no -j (currently breaks)
-pmake -C ${DIR} TARGETARCH=x32_64
-pmake -C ${DIR} TARGETARCH=x32_64 bootstrap-rebuild
-# todo after this point...
-pmake -C ${DIR} PREFIX=${PREFIX} install
+pmake -C ${DIR} TARGETARCH=x32_64 LIBCVER=GLIBC2_31 OBJ_BPREFIX=${PREFIX_BOOTSTRAP}
+
+# this seems to ignore libcver somewhere?
+#pmake -C ${DIR} TARGETARCH=x32_64 LIBCVER=GLIBC2_31 OBJ_REBUILD=${PREFIX_REBUILD} bootstrap-rebuild
 
 export XZ_DEFAULTS="-T 0"
-tar Jcf ${OUTPUT} --transform "s,^./,./tendra-${VERSION}/," -C ${PREFIX} .
+tar Jcf ${OUTPUT} --transform "s,^./,./tendra-${VERSION}/," -C ${PREFIX_BOOTSTRAP} .
 
 if [[ ! -z "${S3OUTPUT}" ]]; then
     s3cmd put --rr ${OUTPUT} ${S3OUTPUT}


### PR DESCRIPTION
* Upgrades to 20.04 (may cause downstream issues later, but for now...)
* Installs a bunch of i386 stuff
* Attempts to build and bootstrap TenDRA

Currently fails with:

```
==> Linking src/tld
/root/tendra/obj.89e5dd28d211-bootstrap/bin/tcc  -o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/tld /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/_partial/src/shared/_partial.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/_partial/src/exds/_partial.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/_partial/src/adt/_partial.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/_partial/src/frontend/_partial.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/arg-parse.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/debug.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/file-name.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/fmt.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/main.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/rename-file.o /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/tdf.o
/usr/bin/ld: errno: TLS definition in /lib32/libc.so.6 section .tbss mismatches non-TLS reference in /root/tendra/obj.89e5dd28d211-rebuild/obj/tld/src/_partial/src/shared/_partial.o
/usr/bin/ld: /lib32/libc.so.6: error adding symbols: bad value
*** Error code 1
```

To reproduce:

```bash
$ docker build --tag test . && docker run test bash buildTenDRA.sh trunk
```

Additionally packaging is not yet working, for discussion.

CC @katef