### PR TITLE
Added ghidra build script

### DIFF
--- a/build/build-ghidra.sh
+++ b/build/build-ghidra.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+# SUDO_PREFIX="sudo"
+SUDO_PREFIX=""
+
+# install binutils and zlib
+echo "Installing binutils and zlib..."
+$SUDO_PREFIX apt-get update && $SUDO_PREFIX apt-get install -y binutils-dev zlib1g-dev
+
+# clone Ghidra fork into /opt/ghidra if it does not already exist
+echo "Cloning Ghidra fork into /opt/ghidra..."
+if [ ! -d "/opt/ghidra" ]; then
+    $SUDO_PREFIX git clone https://github.com/nimashoghi/ghidra.git /opt/ghidra
+fi
+
+# build ghidra decompiler
+echo "Building ghidra decompiler..."
+DECOMPILER_SRC_DIR="/opt/ghidra/Ghidra/Features/Decompiler/src/decompile/cpp"
+pushd $DECOMPILER_SRC_DIR
+make -j
+make -j decomp_opt
+make -j sleigh_opt
+popd
+
+# copy decompiler ('decomp_opt') and sleigh compiler ('sleigh_opt') into /usr/local/bin
+echo "Copying decompiler ('decomp_opt') and sleigh compiler ('sleigh_opt') into /usr/local/bin..."
+$SUDO_PREFIX cp $DECOMPILER_SRC_DIR/decomp_opt /usr/local/bin/ghidra_decomp
+$SUDO_PREFIX cp $DECOMPILER_SRC_DIR/sleigh_opt /usr/local/bin/ghidra_sleigh
+
+# for the supported architectures, use the sleigh compiler to generate the sleigh .sla files
+# supported architectures: x86, x86-64
+echo "Generating sleigh .sla files for supported architectures..."
+SUPPORTED_ARCHS=("x86/data/languages/x86" "x86/data/languages/x86-64")
+PROCESSORS_BASE_DIR="/opt/ghidra/Ghidra/Processors"
+for ARCH in "${SUPPORTED_ARCHS[@]}"
+do
+    echo "Generating $ARCH..."
+    $SUDO_PREFIX ghidra_sleigh $PROCESSORS_BASE_DIR/$ARCH.slaspec
+done
+
+# Move the compiled Processors folder to /usr/local/share/ghidra/Ghidra/Processors
+echo "Moving the compiled Processors folder to /usr/local/share/ghidra/..."
+$SUDO_PREFIX mkdir -p /usr/local/share/ghidra/Ghidra
+$SUDO_PREFIX cp -r $PROCESSORS_BASE_DIR /usr/local/share/ghidra/Ghidra/
+
+echo "Done!"


### PR DESCRIPTION
I was told on the Compiler Explorer Discord that I should post this here.

This script basically does the following:

1. Installs all dependencies needed for Ghidra (binutils-dev and zlib1g-dev)
2. Clones [my fork of the Ghidra repository](https://github.com/nimashoghi/ghidra.git), which fixes a runtime error I had when using Ghidra's decompiler with Compiler Explorer.
3. Builds the Ghidra decompiler tooling and the Ghidra SLEIGH compiler.
4. Uses the Ghidra SLEIGH compiler to generate architecture specification files for x86-64 and x86.
5. Moves these specification files to `/usr/local/share/ghidra/`, so it can be used by the Ghidra compiler explorer tooling.

See [this PR](https://github.com/compiler-explorer/compiler-explorer/pull/2705) for more information.