### PR TITLE
Minor change in cproc, mrustc and rustc_cg_gcc

### DIFF
--- a/build/build-cproc.sh
+++ b/build/build-cproc.sh
@@ -2,13 +2,13 @@
 
 ## $1 : version, currently cproc does not have any and only uses master branch.
 ## $2 : destination: a directory or S3 path (eg. s3://...)
-## $3 : last revision successfully build
+## $3 : last revision successfully build (optional)
 
 set -ex
 
 ROOT=$PWD
 VERSION="${1}"
-LAST_REVISION="${3}"
+LAST_REVISION="${3-}"
 
 if [[ "${VERSION}" != "master" ]]; then
     echo "Only support building master"

--- a/build/build-mrustc.sh
+++ b/build/build-mrustc.sh
@@ -2,12 +2,12 @@
 
 ## $1 : version, like v0.9 (tag) or master (branch)
 ## $2 : destination: a directory or S3 path (eg. s3://...)
-## $3 : last revision successfully build
+## $3 : last revision successfully build (optional)
 set -exu
 
 ROOT=$PWD
 VERSION=$1
-LAST_REVISION=$3
+LAST_REVISION=${3-}
 FULLNAME=mrustc-${VERSION}-$(date +%Y%m%d)
 
 OUTPUT=${ROOT}/${FULLNAME}.tar.xz

--- a/build/build-rustc-cg-gcc.sh
+++ b/build/build-rustc-cg-gcc.sh
@@ -2,13 +2,13 @@
 
 ## $1 : version, currently rustc_cg_gcc does not have any and only uses master branch.
 ## $2 : destination: a directory or S3 path (eg. s3://...)
-## $3 : last revision (as mangled below) successfully build
+## $3 : last revision (as mangled below) successfully build (optional)
 
 set -e
 
 ROOT=$PWD
 VERSION="${1}"
-LAST_REVISION="${3}"
+LAST_REVISION="${3-}"
 
 if [[ "${VERSION}" != "master" ]]; then
     echo "Only support building master"
@@ -19,7 +19,7 @@ GCC_URL="https://github.com/antoyo/gcc.git"
 GCC_BRANCH="master"
 
 CG_GCC_BRANCH="master"
-CG_GCC_URL="https://github.com/antoyo/rustc_codegen_gcc.git"
+CG_GCC_URL="https://github.com/rust-lang/rustc_codegen_gcc.git"
 
 GCC_REVISION=$(git ls-remote --heads "${GCC_URL}" "refs/heads/${GCC_BRANCH}" | cut -f 1)
 CG_GCC_REVISION=$(git ls-remote --heads "${CG_GCC_URL}" "refs/heads/${CG_GCC_BRANCH}" | cut -f 1)


### PR DESCRIPTION
Make the last revision argument optional for easier local use.

Change git URL for rustc_cg_gcc as it's now part of rust-lang:

 https://github.com/rust-lang/rust/pull/87260

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>