### PR TITLE
Improve .NET bits for faster compilation

### DIFF
--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -71,6 +71,8 @@ ${DIR}/./dotnet.sh build -c Release fsapp -o fsapp/out
 ${DIR}/./dotnet.sh build -c Release vbapp -o vbapp/out
 
 # remove files we don't need in CORE_ROOT
+# TODO: remove more stuff/libs nobody will ever use on godbolt
+# Also, from ".dotnet" bootstrap SDK like aspnet stuff, etc.
 rm -rf *.pdb
 rm -rf *.so
 rm -rf *.so.dbg

--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -70,6 +70,11 @@ ${DIR}/./dotnet.sh build -c Release csapp -o csapp/out
 ${DIR}/./dotnet.sh build -c Release fsapp -o fsapp/out
 ${DIR}/./dotnet.sh build -c Release vbapp -o vbapp/out
 
+# remove files we don't need in CORE_ROOT
+rm -rf *.pdb
+rm -rf *.so
+rm -rf *.so.dbg
+
 # Copy bootstrap .NET SDK, needed for 'dotnet build'
 cd ${DIR}
 mv .dotnet/ ${CORE_ROOT}/

--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -62,13 +62,13 @@ cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}/crossgen2
 # Then we should be able to quickly re-build it with --no-restore
 cd ${CORE_ROOT}
 
-./dotnet.sh new classlib -lang "C#" -o csapp
-./dotnet.sh new classlib -lang "F#" -o fsapp
-./dotnet.sh new classlib -lang "VB" -o vbapp
+${DIR}/./dotnet.sh new classlib -lang "C#" -o csapp
+${DIR}/./dotnet.sh new classlib -lang "F#" -o fsapp
+${DIR}/./dotnet.sh new classlib -lang "VB" -o vbapp
 
-./dotnet.sh build -c Release csapp -o csapp/out
-./dotnet.sh build -c Release fsapp -o fsapp/out
-./dotnet.sh build -c Release vbapp -o vbapp/out
+${DIR}/./dotnet.sh build -c Release csapp -o csapp/out
+${DIR}/./dotnet.sh build -c Release fsapp -o fsapp/out
+${DIR}/./dotnet.sh build -c Release vbapp -o vbapp/out
 
 # Copy bootstrap .NET SDK, needed for 'dotnet build'
 cd ${DIR}

--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -58,13 +58,17 @@ cd ../..
 # Copy Checked JITs to CORE_ROOT
 cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}/crossgen2
 
-# Pregenerate a simple console library project
+# Pregenerate a simple console library project per language
 # Then we should be able to quickly re-build it with --no-restore
 cd ${CORE_ROOT}
-mkdir testapp
-cd testapp
-./dotnet.sh new classlib
-./dotnet.sh build -c Release -o out
+
+./dotnet.sh new classlib -lang "C#" -o csapp
+./dotnet.sh new classlib -lang "F#" -o fsapp
+./dotnet.sh new classlib -lang "VB" -o vbapp
+
+./dotnet.sh build -c Release csapp -o csapp/out
+./dotnet.sh build -c Release fsapp -o fsapp/out
+./dotnet.sh build -c Release vbapp -o vbapp/out
 
 # Copy bootstrap .NET SDK, needed for 'dotnet build'
 cd ${DIR}

--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -48,7 +48,7 @@ CORE_ROOT=artifacts/tests/coreclr/Linux.x64.Release/Tests/Core_Root
 ./build.sh Clr+Libs -c Release --ninja
 
 # Build Checked JIT compilers (only Checked JITs are able to print codegen)
-./build.sh Clr.Runtime -c Checked --ninja
+./build.sh Clr.AllJits -c Checked --ninja
 cd src/tests
 
 # Generate CORE_ROOT for Release


### PR DESCRIPTION
cc @hez2010 @partouf 
This puts into the docker everything we need for fast (~1s) "change C#/F#/VB.NET -> observe codegen" loop.

the content of the root folder is:
```
[crossgen2] - contains crossgen binary with checked jits
[.dotnet] - bootstrap .NET SDK for "dotnet build -c Release --no-restore" command for user's code
[testapp] - prebuilt "Class Library" empty app
*.* - base class libraries needed for prejitting
```

The loop (for e.g. C#) should look like this:
1) User writes C# code directly to `csapp/Class1.cs`
2) Build user's code:
```
DOTNET_TC_QuickJitForLoops=1 ./.dotnet/dotnet build csapp -c Release -o csapp/out /p:AllowUnsafeBlocks=true --no-restore --no-dependencies --nologo
```
3) Prejit using crossgen2:
```
DOTNET_TC_QuickJitForLoops=1 ./.dotnet/dotnet ./crossgen2/crossgen2.dll csapp/out/csapp.dll --out tmp -r "*.dll" --parallelism 1 --codegenopt:NgenDisasm="*" %additional args%`
```

NOTE: `DOTNET_TC_QuickJitForLoops=1` slightly speeds up both msbuild and crossgen (shaves ~0.5s for me locally)

In future, I'll add a quick way to get codegen from JIT directly instead of AOT (but it's better to keep AOT as a separate mode) since its codegen is better in general. Via a prebuilt console app that does `RuntimeHelpers.PrepareMethod`


For me locally the loop takes ~1.2s on my laptop for a changed C# code.