### PR TITLE
Fix build-dotnet.sh

### DIFF
--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -3,6 +3,7 @@
 set -ex
 
 VERSION=$1
+SDK_VERSION=$2
 if echo ${VERSION} | grep 'trunk'; then
     BRANCH=main
 else
@@ -58,9 +59,16 @@ cd ../..
 cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}
 cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}/crossgen2
 
-# Copy bootstrap .NET SDK, needed for 'dotnet build'
+# Install .NET SDK, needed for 'dotnet build'
 cd ${DIR}
-mv .dotnet/ ${CORE_ROOT}/
+if [[ ! -z ${SDK_VERSION} ]]; then
+  # Download the specified version of .NET SDK
+  curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version ${SDK_VERSION} --install-dir ${CORE_ROOT}/.dotnet
+else
+  # Use the runtime bootstrapping SDK
+  mv .dotnet/ ${CORE_ROOT}/
+fi
+
 
 XZ_OPT=-2 tar Jcf ${OUTPUT} ${CORE_ROOT}
 

--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -41,7 +41,6 @@ DIR=$(pwd)/dotnet/runtime
 git clone --depth 1 -b ${BRANCH} ${URL} ${DIR}
 cd ${DIR}
 
-
 CORE_ROOT=artifacts/tests/coreclr/Linux.x64.Release/Tests/Core_Root
 
 # Build everything in Release mode
@@ -56,29 +55,8 @@ cd src/tests
 cd ../..
 
 # Copy Checked JITs to CORE_ROOT
+cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}
 cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}/crossgen2
-
-# Pregenerate a simple console library project per language
-# Then we should be able to quickly re-build it with --no-restore
-cd ${CORE_ROOT}
-
-${DIR}/./dotnet.sh new classlib -lang "C#" -o csapp
-${DIR}/./dotnet.sh new classlib -lang "F#" -o fsapp
-${DIR}/./dotnet.sh new classlib -lang "VB" -o vbapp
-
-# Ignore repo's rules and analyzers
-BUILD_TEMPLATES_FLAGS="-c Release /p:TreatWarningsAsErrors=false /p:RunAnalyzers=false"
-
-${DIR}/./dotnet.sh build ${BUILD_TEMPLATES_FLAGS} csapp -o csapp/out
-${DIR}/./dotnet.sh build ${BUILD_TEMPLATES_FLAGS} fsapp -o fsapp/out
-${DIR}/./dotnet.sh build ${BUILD_TEMPLATES_FLAGS} vbapp -o vbapp/out
-
-# remove files we don't need in CORE_ROOT
-# TODO: remove more stuff/libs nobody will ever use on godbolt
-# Also, from ".dotnet" bootstrap SDK like aspnet stuff, etc.
-rm -rf *.pdb
-rm -rf *.so
-rm -rf *.so.dbg
 
 # Copy bootstrap .NET SDK, needed for 'dotnet build'
 cd ${DIR}


### PR DESCRIPTION
It turns out that we cannot use a pre-generated project for no-restore build between different machines (`project.assets.json` is environment-specific), so I removed them.

But we do can use `dotnet build` instead of `dotnet publish` to make build faster, which will be included in a separate PR in compiler-explorer later.

Also, I added the ability to download specified version of dotnet sdk (optional), so users can try out new features in the main branch.

Sample build command: `./build-dotnet.sh trunk 7.0.100-preview.5.22229.2`. BTW, does the CE infra support passing two args to build script?

/cc: @partouf 