### PR TITLE
Build the jakt programming language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,9 @@ RUN apt install -y -q patchelf
 
 RUN apt install -y -q libxml2-dev
 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+
 RUN mkdir -p /root
 COPY build /root/
 

--- a/build/build-jakt.sh
+++ b/build/build-jakt.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+## $1 : version
+## $2 : destination: a directory or S3 path (eg. s3://...)
+## $3 : last revision successfully build
+
+set -ex
+ROOT=$(pwd)
+VERSION="$1"
+LAST_REVISION="$3"
+
+if [[ -z "${VERSION}" ]]; then
+    echo Please pass a version to this script
+    exit
+fi
+
+if echo "${VERSION}" | grep 'trunk'; then
+    VERSION=trunk-$(date +%Y%m%d)
+    URL=https://github.com/SerenityOS/jakt
+    BRANCH=main
+else
+	echo "Versions other than trunk are not currently supported"
+	exit 1
+fi
+
+FULLNAME=jakt-${VERSION}.tar.xz
+OUTPUT=${ROOT}/${FULLNAME}
+S3OUTPUT=
+if [[ $2 =~ ^s3:// ]]; then
+    S3OUTPUT=$2
+else
+    if [[ -d "${2}" ]]; then
+        OUTPUT=$2/${FULLNAME}
+    else
+        OUTPUT=${2-$OUTPUT}
+    fi
+fi
+
+JAKT_REVISION=$(git ls-remote --heads ${URL} refs/heads/${BRANCH} | cut -f 1)
+REVISION="jakt-${JAKT_REVISION}"
+
+echo "ce-build-revision:${REVISION}"
+echo "ce-build-output:${OUTPUT}"
+
+if [[ "${REVISION}" == "${LAST_REVISION}" ]]; then
+    echo "ce-build-status:SKIPPED"
+    exit
+fi
+
+SUBDIR=jakt-${VERSION}
+STAGING_DIR=/opt/compiler-explorer/jakt-${VERSION}
+
+rm -rf "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}"
+
+rm -rf "${SUBDIR}"
+git clone -q --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${SUBDIR}"
+
+cd "${SUBDIR}"
+
+cargo build --release
+cargo run --release -- selfhost/main.jakt
+
+mv target/release/jakt ./jakt-rs
+mv build/main ./jakt-selfhost
+
+export XZ_DEFAULTS="-T 0"
+tar Jcf "${OUTPUT}" --transform "s,^./,./${SUBDIR}/," -C "${STAGING_DIR}" .
+
+if [[ -n "${S3OUTPUT}" ]]; then
+    aws s3 cp --storage-class REDUCED_REDUNDANCY "${OUTPUT}" "${S3OUTPUT}"
+fi
+
+echo "ce-build-status:OK"


### PR DESCRIPTION
Jakt currently needs to be build using Rust. So download a rust release
from infra.

And the ce_install for Rust needs patchelf under /opt/compiler-explorer,
so symlink it there.

Note: Installing a Rust version using infra currently downloads that version for all architectures that Rust supports, which is way overkill here. But as far as I can tell, there's currently no way to configure the architectures that are downloaded in infra. If I just missed how to do that, please tell me.