### PR TITLE
Jakt: Add cargo to path before build

### DIFF
--- a/build/build-jakt.sh
+++ b/build/build-jakt.sh
@@ -4,6 +4,9 @@
 ## $2 : destination: a directory or S3 path (eg. s3://...)
 ## $3 : last revision successfully build
 
+# Make sure cargo is in PATH
+export PATH="$PATH":"$HOME"/.cargo/bin
+
 set -ex
 ROOT=$(pwd)
 VERSION="$1"


### PR DESCRIPTION
This should fix https://github.com/compiler-explorer/misc-builder/pull/40 so that cargo is found in the Jakt build script.

cc @partouf