### PR TITLE
Fix rustc_cg_gcc build

### DIFF
--- a/build/build-rustc-cg-gcc.sh
+++ b/build/build-rustc-cg-gcc.sh
@@ -191,6 +191,11 @@ mv ./rustc_codegen_gcc/target/release/librustc_codegen_gcc.so toolroot/lib
 mv ./rustc_codegen_gcc/build_sysroot/sysroot toolroot/
 
 ##
+## Fixup RPATH for the librustc_codegen_gcc.so so it can find libgccjit
+##
+patchelf --add-rpath '$ORIGIN/' toolroot/lib/librustc_codegen_gcc.so
+
+##
 ## Simple sanity checks:
 ## - check for assembly output
 ## - check for correct exec output


### PR DESCRIPTION
After some change (probably in rustc_cg_gcc?), the correct libgccjit can't be found by the dynamic loader:

  error: couldn't load codegen backend "librustc_codegen_gcc.so": libgccjit.so.0: cannot open shared object file: No such file or directory

even with the library correctly installed along the backend.

Patching the lib's RPATH with patchelf fixes this issue.

fixes #4047

Signed-off-by: Marc Poulhiès <dkm@kataplop.net>