### PR TITLE
Fix ROCm tarball paths

### DIFF
--- a/build/build-rocm-hip.sh
+++ b/build/build-rocm-hip.sh
@@ -96,7 +96,7 @@ popd # build
 popd # hipamd
 
 export XZ_DEFAULTS="-T 0"
-tar Jcf "${OUTPUT}" --transform "s,^./,./${FULLNAME}/," "${DEST}"
+tar Jcf "${OUTPUT}" --transform "s,^./,./${FULLNAME}/," -C "${DEST}" .
 
 if [[ -n "${S3OUTPUT}" ]]; then
     aws s3 cp --storage-class REDUCED_REDUNDANCY "${OUTPUT}" "${S3OUTPUT}"


### PR DESCRIPTION
This changes the paths in generated tarball from

    opt/compiler-explorer/libs/rocm/5.2.3/*

to

    ./hip-amd-rocm-5.2.3/*

to match the default expectations for library tarballs in infra. I think this should let me drop the `untar_dir: opt/compiler-explorer/libs/rocm/{{name}}` from https://github.com/compiler-explorer/infra/pull/834.