### PR TITLE
Add rocm-5.3.2 compiler to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 4.5.2'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.0.2'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.1.3'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.2.3'
+RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.3.1'
 
 
 RUN cpanm Modern::Perl

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 4.5.2'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.0.2'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.1.3'
 RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.2.3'
-RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.3.1'
+RUN /opt/compiler-explorer/infra/bin/ce_install install 'clang-rocm 5.3.2'
 
 
 RUN cpanm Modern::Perl


### PR DESCRIPTION
I believe this change will enable building HIP for ROCm 5.3.2 with `./build-rocm-hip.sh 5.3.2`. Though, first the clang-builder must be run with `./build.sh rocm-5.3.2` so that there is an S3 tarball for the compiler.

EDIT: I originally opened this PR for ROCm 5.3.1, but it turns out that version will never have a full release due to an issue found right after tagging. I'll mark this PR as ready when ROCm 5.3.2 has released.