### PR TITLE
Explicitly disable HIP Profiling API

### DIFF
--- a/build/build-rocm-hip.sh
+++ b/build/build-rocm-hip.sh
@@ -89,7 +89,8 @@ cmake -S.. -B. -DCMAKE_BUILD_TYPE=Release \
   -DAMD_OPENCL_PATH="${ROOT}/ROCm-OpenCL-Runtime-${ROCM_VERSION}" \
   -DROCCLR_PATH="${ROOT}/ROCclr-${ROCM_VERSION}" \
   -DCMAKE_PREFIX_PATH="${COMP};${DEST}" \
-  -DCMAKE_INSTALL_PREFIX="${DEST}"
+  -DCMAKE_INSTALL_PREFIX="${DEST}" \
+  -DUSE_PROF_API=OFF
 ninja
 ninja install
 popd # build


### PR DESCRIPTION
Prior to ROCm 5.3, the profiling API was being gracefully disabled by default, possibly because libroctracer was not found at configure time. However, in ROCm 5.3, a new dependency on CppHeaderParser was added for building the profiling API and its absence was treated as a fatal error.

@RubenRBS, this should fix the issue you mentioned in https://github.com/compiler-explorer/infra/pull/857.