### PR TITLE
build dotnet as "official"

### DIFF
--- a/build/build-dotnet.sh
+++ b/build/build-dotnet.sh
@@ -41,10 +41,13 @@ DIR=$(pwd)/dotnet/runtime
 git clone --depth 1 -b ${BRANCH} ${URL} ${DIR}
 cd ${DIR}
 
+commit="$(git rev-parse HEAD)"
+echo "HEAD is at: $commit"
+
 CORE_ROOT=artifacts/tests/coreclr/Linux.x64.Release/Tests/Core_Root
 
 # Build everything in Release mode
-./build.sh Clr+Libs -c Release --ninja
+./build.sh Clr+Libs -c Release --ninja -ci -p:OfficialBuildId=$(date +%Y%m%d)-99
 
 # Build Checked JIT compilers (only Checked JITs are able to print codegen)
 ./build.sh Clr.AllJits -c Checked --ninja
@@ -53,6 +56,9 @@ cd src/tests
 # Generate CORE_ROOT for Release
 ./build.sh Release generatelayoutonly
 cd ../..
+
+# Write version info for .NET 6 (it doesn't have crossgen2 --version)
+echo "${VERSION:1}+${commit}" > ${CORE_ROOT}/version.txt
 
 # Copy Checked JITs to CORE_ROOT
 cp artifacts/bin/coreclr/Linux.x64.Checked/libclrjit*.so ${CORE_ROOT}


### PR DESCRIPTION
with `-ci` and `-p:OfficialBuildId=<seed>`, we get the proper version info in compiled binaries out of dotnet's build infrastructure:

```sh
for v in trunk v7.0.0 v6.0.11; do
  rm -rf dotnet
  sh build/build-dotnet.sh $v
  dotnet/runtime/artifacts/tests/coreclr/Linux.x64.Release/Tests/Core_Root/crossgen2/crossgen2 --version
done
```

before (no `-p:OfficialBuildId=`):
```
8.0.0-dev
7.0.0-dev
```

after (with `-ci` and `-p:OfficialBuildId=`):
```
8.0.0-alpha.1.22579.99+4b9e3c0f72416de5fc40cc6fb21974967542d5ad
7.0.0-rtm.22579.99+d099f075e45d2aa6007a22b71b45a08758559f80
```

in 6.0, crossgen2 doesn't have `--version` option so i've manually written version.txt in the tarball for fallback.

@mattgodbolt, @partouf, next, i'll update compiler-explorer/compiler-explorer  to display on first line as comment in asm viewer (similar to [sharplab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIGYACMhgYQYG8aHunHiUGAWQAUASg4MAvjUlA=)). it's easier to find the exact version to track things down, also commit from part after `+` sign to find the source code `https://github.com/dotnet/runtime/commits/<commit>`.