### PR TITLE
build-spirv-tools.sh: remove depth while cloning to get needed tags

### DIFF
--- a/build/build-spirv-tools.sh
+++ b/build/build-spirv-tools.sh
@@ -47,7 +47,7 @@ OUTPUT=$(realpath "${OUTPUT}")
 
 export PATH=${PATH}:/cmake/bin
 
-git clone --depth 1 "${URL}" --branch "${BRANCH}"
+git clone "${URL}" --branch "${BRANCH}"
 pushd SPIRV-Tools
 
 ./utils/git-sync-deps


### PR DESCRIPTION
utils/update_build_version.py needs tag to run. Cloning with `--depth 1` does not get them, and then produce an error when building spirv-tools.

removing `--depth 1` allows to get tag and fix the build of spirv-tools