### PR TITLE
feat: install `cpp2util.h`

### DIFF
--- a/misc/build-cppfront.sh
+++ b/misc/build-cppfront.sh
@@ -54,7 +54,7 @@ STAGING_DIR=/opt/compiler-explorer/cppfront-${VERSION}
 GXXPATH=/opt/compiler-explorer/gcc-12.1.0
 
 rm -rf "${STAGING_DIR}"
-mkdir -p "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}/include"
 
 rm -rf "${SUBDIR}"
 git clone -q --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${SUBDIR}"
@@ -62,6 +62,7 @@ git clone -q --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${SUBDIR}"
 cd "${SUBDIR}"
 
 "${GXXPATH}/bin/g++" -O2 -std=c++20 -static -o "${STAGING_DIR}/cppfront" source/cppfront.cpp
+cp include/cpp2util.h "${STAGING_DIR}/include"
 
 export XZ_DEFAULTS="-T 0"
 tar Jcf "${OUTPUT}" --transform "s,^./,./${SUBDIR}/," -C "${STAGING_DIR}" .


### PR DESCRIPTION
I think this installs the `cpp2util.h` the `cppfront` executable was compiled with.

I have a CMake project to build Cpp2: <https://cpp2.godbolt.org/z/bKn3GvnEG>.

Up until now, I have been getting by having a local `cpp2util.h` with contents
```C++
#include "https://raw.githubusercontent.com/hsutter/cppfront/main/include/cpp2util.h"
```
But that can stop working when `cpp2util.h` changes until `cppfront` is updated.
It also breaks existing links.
Temporarily changing the local `cpp2util.h` also works until `cppfront` is updated.
Leaving behind links with such a file won't work after that.

The only right answer is to use the `cpp2util.h` the `cppfront` was compiled with.
The intent of this PR is to couple these files, as is intended to work, in the installation of `cppfront`.