### PR TITLE
Initial support for pythran

### DIFF
--- a/Dockerfile.pythran
+++ b/Dockerfile.pythran
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get --assume-yes update \
+    && DEBIAN_FRONTEND=noninteractive apt-get --assume-yes \
+    --no-install-recommends install \
+        ca-certificates \
+        curl \
+        git \
+        bc \
+        make \
+        xz-utils
+
+
+RUN mkdir -p /root
+
+RUN mkdir -p /root/miniconda3
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /root/miniconda3/miniconda.sh
+RUN bash /root/miniconda3/miniconda.sh -b -u -p /root/miniconda3
+RUN rm -rf /root/miniconda3/miniconda.sh
+
+ENV PATH="/root/miniconda3/bin:${PATH}"
+
+COPY pythran/ /root/
+COPY common.sh /root/
+
+WORKDIR /root

--- a/pythran/build.sh
+++ b/pythran/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -exu
+source common.sh
+
+VERSION="$1"
+
+ROOT=$(pwd)
+FULLNAME=pythran-${VERSION}.tar.xz
+OUTPUT=${ROOT}/${FULLNAME}
+
+if [[ -d "${2}" ]]; then
+   OUTPUT=$2/${FULLNAME}
+else
+   OUTPUT=${2-$OUTPUT}
+fi
+
+STAGING_DIR="/opt/compiler-explorer/pythran/pythran-${VERSION}"
+
+conda init
+
+eval "$(conda shell.bash hook)"
+conda activate base
+
+conda install conda-build -y
+conda deactivate
+
+PACKAGES="gcc_linux-64 \
+    gxx_linux-64 \
+    libgfortran-ng \
+    libgfortran5 \
+    libgcc-ng \
+    libgomp \
+    libstdcxx-ng"
+
+pushd /root/scratch
+conda build .
+popd
+
+mkdir -p $(dirname "$STAGING_DIR")
+
+conda create -y -p "$STAGING_DIR"
+
+## This may need some fine tuning if pythran bumps its dep on gcc from 13.2 to
+## something different.
+
+for P in $PACKAGES; do
+    conda install -y --use-local "$P=13.2.0=external*" -p "$STAGING_DIR"
+done
+
+conda install -y -c conda-forge pythran="$VERSION" -p "$STAGING_DIR"
+
+complete "${STAGING_DIR}" "pythran-${VERSION}" "${OUTPUT}"

--- a/pythran/scratch/meta.yaml
+++ b/pythran/scratch/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "13.2.0" %}
+{% set build = 0 %}
+
+package:
+  name: gcc-dummies
+  version: {{ version }}
+
+build:
+  number: {{ build }}
+
+outputs:
+  - name: gcc_linux-64
+    string: external_{{ build }}
+  - name: gxx_linux-64
+    string: external_{{ build }}
+  - name: libgfortran-ng
+    string: external_{{ build }}
+  - name: libgfortran5
+    string: external_{{ build }}
+  - name: libgcc-ng
+    string: external_{{ build }}
+  - name: libgomp
+    string: external_{{ build }}
+  - name: libstdcxx-ng
+    string: external_{{ build }}
+
+about:
+  license: GPL-3.0-only
+  summary: Dummy package for external GCC compiler and libs.


### PR DESCRIPTION
The build is a bit atypical. In order to get a
self-sufficient/relocatable "compiler", we use the conda package... But we cheat a bit by faking its dependencies on a c++ compiler. The conda package has its own dep and will insteall its own copy of gcc/clang... But we have plenty of C++ compilers, so all the gcc deps are stubbed. Pythran knows how to look for g++ using CXX or by relying on PATH.

refs https://github.com/compiler-explorer/compiler-explorer/issues/6079