### PR TITLE
Update build.sh; introduce version

### DIFF
--- a/hylo/build.sh
+++ b/hylo/build.sh
@@ -38,6 +38,7 @@ git clone -q --depth 1 --single-branch --recursive -b "${BRANCH}" "${URL}" "hylo
 cd "hylo-${VERSION}"
 swift package resolve
 .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh /usr/local/lib/pkgconfig/llvm.pc
+./Tools/set-hc-version.sh
 swift build --static-swift-stdlib -c release --product hc
 
 # Copy all shared object dependencies into the release directory to create a hermetic build, per


### PR DESCRIPTION
Set version/commit hash in the build
Without this step ``hc --version`` always returns ``unknown``

https://github.com/hylo-lang/hylo/pull/1434
This is performed in hylo's CI/CD pipeline but since we do a manual build, it has to be explicitly performed.

This might be helpful when reporting issues to hylo or CE.