### PR TITLE
Update Swift for hylo to version 5.10

### DIFF
--- a/Dockerfile.hylo
+++ b/Dockerfile.hylo
@@ -37,8 +37,8 @@ RUN mkdir /root/.ssh \
 RUN git clone https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra
 
 RUN cd /opt/compiler-explorer/infra && make ce
-RUN /opt/compiler-explorer/infra/bin/ce_install install 'swift 5.9'
-ENV PATH="${PATH}:/opt/compiler-explorer/swift-5.9/usr/bin"
+RUN /opt/compiler-explorer/infra/bin/ce_install install 'swift 5.10'
+ENV PATH="${PATH}:/opt/compiler-explorer/swift-5.10/usr/bin"
 
 RUN mkdir -p /root
 COPY hylo /root/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the docker images used to build some of the more...esoteric...tools used on the 
 For example, it builds the 6502 compiler.
 
 It's in the process of being broken into smaller docker files, and/or separate repos as appropriate.
-What "as appropriate" means is stlil being workde on. Each dockerfile is for one group of related
+What "as appropriate" means is still being worked on. Each dockerfile is for one group of related
 things, building a `XXX-builder` for the `Dockerfile.XXX` file. The `misc` Dockerfile itself is
 for the super misc-y things that really only are one-off, though that's still being split up.
 
@@ -14,14 +14,19 @@ If you add a new Dockerfile, you'll need to edit the matrix in the `.github/work
 
 # Testing locally
 
-Note: make sure you `chmod +x build/build-yourcompiler.sh` first
+Note: make sure you `chmod +x yourlanguage/build-yourcompiler.sh` first.
 
-```
+```shell
+# Building the Docker image with tag `builder`
 docker build -t builder -f Dockerfile.misc .
+
+# Running the build script in the container directly
 docker run --rm -v/tmp/out:/build builder ./build-yourcompiler.sh trunk /build
+
+# Alternative to running the build script 
+#  (It first starts a bash terminal inside the container, so it's easier for debugging.)
+docker run -t -i miscbuilder bash
+./build-yourcompiler.sh trunk /build
 ```
 
-### Alternative to run (for better debugging)
-
-* `docker run -t -i miscbuilder bash`
-* `./build-yourcompiler.sh trunk`
+> Note: Different compiler builder scripts may require different command line arguments, check your script for details.

--- a/hylo/build.sh
+++ b/hylo/build.sh
@@ -9,7 +9,7 @@ source common.sh
 
 ROOT=$(pwd)
 VERSION=$1
-URL="https://github.com/hylo-lang/hyloc"
+URL="https://github.com/hylo-lang/hylo"
 
 if echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)


### PR DESCRIPTION
This MR hopefully fixes the build for the Hylo compiler by updating swift version to 5.10.

I also updated the README.md because I got confused for a moment by skipping `docker build` entirely by just seeing there is an alternative to run (and for run, I just wrongly assumed it includes the whole previous section).