### PR TITLE
Update build script for rocm

### DIFF
--- a/rocm/patches/hipamd-rocm-6.0.2-0001-fix-cmake
+++ b/rocm/patches/hipamd-rocm-6.0.2-0001-fix-cmake
@@ -1,0 +1,15 @@
+diff --git a/hipamd/CMakeLists.txt b/hipamd/CMakeLists.txt
+index 272ebca35..cab007649 100755
+--- a/hipamd/CMakeLists.txt
++++ b/hipamd/CMakeLists.txt
+@@ -402,8 +402,8 @@ if (NOT ${HIPCC_BIN_DIR} STREQUAL "")
+   install(PROGRAMS ${HIPCC_BIN_DIR}/hipcc.pl DESTINATION bin)
+   install(PROGRAMS ${HIPCC_BIN_DIR}/hipconfig.pl DESTINATION bin)
+   install(PROGRAMS ${HIPCC_BIN_DIR}/hipvars.pm DESTINATION bin)
+-  install(PROGRAMS ${HIPCC_BIN_DIR}/hipcc.bat DESTINATION bin)
+-  install(PROGRAMS ${HIPCC_BIN_DIR}/hipconfig.bat DESTINATION bin)
++  #install(PROGRAMS ${HIPCC_BIN_DIR}/hipcc.bat DESTINATION bin)
++  #install(PROGRAMS ${HIPCC_BIN_DIR}/hipconfig.bat DESTINATION bin)
+ endif()
+
+ #############################


### PR DESCRIPTION
Change github URL name to ROCm.

Get device libs, comgr and hipcc from llvm for ROCm 6.1 and above.

Make the script work for ROCm version above 5.7.