### PR TITLE
Fix rocm/build.sh

### DIFF
--- a/rocm/build.sh
+++ b/rocm/build.sh
@@ -59,7 +59,7 @@ done
 cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release \
   -GNinja \
   -DCMAKE_PREFIX_PATH="${COMP}" \
-  -DCMAKE_INSTALL_PREFIX="${COMP}"
+  -DCMAKE_INSTALL_PREFIX="${DEST}"
 ninja -C build
 ninja -C build install
 popd


### PR DESCRIPTION
Install device libs to /opt/compiler-explorer/libs/rocm/6.1.2 instead of /opt/compiler-explorer/clang-rocm-6.1.2 since somehow device libs built by rocm/build.sh for rocm 6.1.2 are not added to clang-rocm-6.1.2 zip file.

/opt/compiler-explorer/libs/rocm/6.1.2 is the location for device libs in the official rocm build any way. This can also avoid --rocm-device-lib-path since --rocm-path will be sufficient to find the device libs.