### PR TITLE
Copy all headers to fix cpp1 build on cpp2.godbolt.org

### DIFF
--- a/misc/build-cppfront.sh
+++ b/misc/build-cppfront.sh
@@ -62,7 +62,7 @@ git clone -q --depth 1 --single-branch -b "${BRANCH}" "${URL}" "${SUBDIR}"
 cd "${SUBDIR}"
 
 "${GXXPATH}/bin/g++" -O2 -std=c++20 -static -o "${STAGING_DIR}/cppfront" source/cppfront.cpp
-cp include/cpp2util.h "${STAGING_DIR}/include"
+cp include/* "${STAGING_DIR}/include"
 
 export XZ_DEFAULTS="-T 0"
 tar Jcf "${OUTPUT}" --transform "s,^./,./${SUBDIR}/," -C "${STAGING_DIR}" .


### PR DESCRIPTION
https://github.com/compiler-explorer/compiler-explorer/issues/6721
I don't have an environment set up to test this, so hopefully this is at least helpful.
