### PR TITLE
Point build.sh back to main Hylo repository

### DIFF
--- a/hylo/build.sh
+++ b/hylo/build.sh
@@ -9,7 +9,7 @@ source common.sh
 
 ROOT=$(pwd)
 VERSION=$1
-URL="https://github.com/tothambrus11/hylo"
+URL="https://github.com/hylo-lang/hylo"
 
 if echo "${VERSION}" | grep 'trunk'; then
     VERSION=trunk-$(date +%Y%m%d)


### PR DESCRIPTION
The temporary fix is no longer needed; it has been upstreamed to the main repo. Thanks @tothambrus11 for the original fix!