### PR TITLE
Add Dockerfile and build script for c2rust

### DIFF
--- a/Dockerfile.c2rust
+++ b/Dockerfile.c2rust
@@ -1,0 +1,24 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386
+RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
+    apt install -y -q \
+    build-essential \
+    clang \
+    cmake \
+    curl \
+    git \
+    libclang-dev \
+    libssl-dev \
+    llvm \
+    pkg-config \
+    python3
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+
+RUN mkdir -p /root
+COPY c2rust /root/
+COPY common.sh /root/
+
+WORKDIR /root

--- a/c2rust/build.sh
+++ b/c2rust/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -exu
+source common.sh
+source $HOME/.cargo/env
+
+## $1 : version, like v0.9 (tag) or master (branch)
+## $2 : destination: a directory or S3 path (eg. s3://...)
+## $3 : last revision successfully built (optional)
+
+VERSION=$1
+
+# TODO: Add support for building tagged releases.
+if [[ "${VERSION}" != "master" ]]; then
+    echo "Only support building master"
+    exit 1
+fi
+
+VERSION=master-$(date +%Y%m%d)
+BRANCH=master
+
+URL=https://github.com/immunant/c2rust
+
+FULLNAME=c2rust-${VERSION}.tar.xz
+OUTPUT=$2/${FULLNAME}
+
+REVISION="c2rust-$(get_remote_revision "${URL}" "heads/${BRANCH}")"
+LAST_REVISION="${3:-}"
+
+initialise "${REVISION}" "${OUTPUT}" "${LAST_REVISION}"
+
+OUT=$(pwd)/out
+DIR=$(pwd)/c2rust
+BUILD=${DIR}/target/release
+
+git clone --depth 1 -b "${BRANCH}" "${URL}" "${DIR}"
+
+cd $DIR
+rustup toolchain install
+cargo build --release
+mkdir -p "${OUT}"
+
+cp "${BUILD}/c2rust" "${BUILD}/c2rust-transpile" "${OUT}"
+
+complete "${OUT}" "c2rust-${VERSION}" "${OUTPUT}"


### PR DESCRIPTION
Add files for building c2rust from source. See https://github.com/compiler-explorer/compiler-explorer/pull/7475 for PR adding c2rust support to the compiler explorer itself.

I wasn't sure if this is the correct way to add support for building c2rust. I based this on the lc3 build since it's also building a Rust project from source. Let me know if this is the wrong approach.