### PR TITLE
Build c2rust against a clang that is available on CE

### DIFF
--- a/Dockerfile.c2rust
+++ b/Dockerfile.c2rust
@@ -14,9 +14,27 @@ RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
     llvm \
     patchelf \
     pkg-config \
-    python3
+    python3.9 \
+    python3.9-venv \
+    zlib1g-dev
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+
+RUN mkdir -p /opt/compiler-explorer
+
+# Add github public key to known_hosts, to enable interaction-less clone
+RUN mkdir /root/.ssh \
+    && touch /root/.ssh/known_hosts \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts
+RUN git clone https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra
+
+RUN cd /opt/compiler-explorer/infra && make ce
+
+# this needs to be kept in sync with the `ldPath` set for `c2rust` in
+# https://github.com/compiler-explorer/compiler-explorer/blob/main/etc/config/c.amazon.properties
+ENV CLANG=19.1.0
+
+RUN /opt/compiler-explorer/infra/bin/ce_install install "clang $CLANG"
 
 RUN mkdir -p /root
 COPY c2rust /root/

--- a/c2rust/build.sh
+++ b/c2rust/build.sh
@@ -37,15 +37,9 @@ git clone --depth 1 -b "${BRANCH}" "${URL}" "${DIR}"
 
 cd $DIR
 rustup toolchain install
-cargo build --release
+LLVM_CONFIG_PATH=/opt/compiler-explorer/clang-$CLANG/bin/llvm-config cargo build --release
 mkdir -p "${OUT}"
 
 cp "${BUILD}/c2rust" "${BUILD}/c2rust-transpile" "${OUT}"
-
-# Copy all dependency .so files into the output dir and then set the RPATH to
-# $ORIGIN so that the local version gets used instead of whatever is insalled
-# globally.
-cp $(ldd "${OUT}"/* | grep -E  '=> /' | grep -Ev 'lib(pthread|c|dl|rt)\.so' | awk '{print $3}' | uniq) "${OUT}"
-patchelf --set-rpath '$ORIGIN' $"$OUT"/*
 
 complete "${OUT}" "c2rust-${VERSION}" "${OUTPUT}"


### PR DESCRIPTION
Resolves https://github.com/compiler-explorer/compiler-explorer/issues/7592.

`c2rust` needs a complete working clang installation, so compiling against the system clang and copying the clang/LLVM `.so`s means that `c2rust` will not find some system headers. This PR builds `c2rust` against a clang that is available on CE instead.

Requires https://github.com/compiler-explorer/compiler-explorer/pull/7696 because clang’s `lib/` dir is not in the default library search path.