### PR TITLE
Build Miri for Rust

### DIFF
--- a/Dockerfile.miri
+++ b/Dockerfile.miri
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
+    apt install -y -q \
+    build-essential \
+    curl \
+    file \
+    git \
+    patchelf \
+    python3 \
+    python3-venv \
+    xz-utils
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+
+# Add github public key to known_hosts, to enable interaction-less clone
+RUN mkdir /root/.ssh \
+    && touch /root/.ssh/known_hosts \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts
+RUN git clone https://github.com/compiler-explorer/infra /opt/compiler-explorer/infra
+
+RUN cd /opt/compiler-explorer/infra && make ce
+
+RUN mkdir -p /root
+COPY miri /root/
+COPY common.sh /root/
+
+WORKDIR /root

--- a/miri/build.sh
+++ b/miri/build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euxo pipefail
+source common.sh
+
+VERSION="${1}"
+LAST_REVISION="${3-}"
+
+if [[ "${VERSION}" != "nightly" ]]; then
+    echo "Only support building nightly"
+    exit 1
+fi
+
+BASENAME=miri-${VERSION}-$(date +%Y%m%d)
+FULLNAME="${BASENAME}.tar.xz"
+OUTPUT=$2/${FULLNAME}
+
+REVISION=${BASENAME}
+LAST_REVISION="${3:-}"
+
+initialise "${REVISION}" "${OUTPUT}" "${LAST_REVISION}"
+
+# update infra
+pushd /opt/compiler-explorer/infra
+git pull
+make ce
+popd
+
+/opt/compiler-explorer/infra/bin/ce_install --enable nightly install compilers/rust/newer/nightly nightly
+
+RUST=/opt/compiler-explorer/rust-miri-${VERSION}
+
+mv /opt/compiler-explorer/rust-nightly ${RUST}
+
+# put `rustup` on `$PATH`
+source .cargo/env
+
+rustup toolchain link miri ${RUST}
+rustup default miri
+
+export MIRI_SYSROOT=${RUST}/miri-sysroot
+
+for manifest_path in ${RUST}/lib/rustlib/manifest-rust-std-*; do
+    cargo miri setup --target=${manifest_path#*/manifest-rust-std-} --verbose
+done
+
+complete "${RUST}" "rust-miri-${VERSION}" "${OUTPUT}"


### PR DESCRIPTION
Miri needs a special pre-built standard library which is normally built on-demand when using `cargo miri` and cached locally. This standard library needs to match the exact nightly version of the compiler. The rest of Miri is already installed by `./bin/ce_install ...`.

This PR builds this sysroot for all architectures. If this is too much (due to storage/build time requirements), this could be restricted to the more common architectures.

Because the sysroot/standard library version must exactly match the compiler version, this build includes the full Rust `nightly` compiler (so there are no conflicts depending on when Miri and Rust `nightly` are updated on the runners).

Building the sysroot needs the Rust standard library sources, so this PR requires https://github.com/compiler-explorer/infra/pull/1630.

See https://github.com/compiler-explorer/compiler-explorer/issues/2563.