### PR TITLE
[miri] install `rust-src` component to be able to build the miri sysroot

### DIFF
--- a/miri/build.sh
+++ b/miri/build.sh
@@ -49,7 +49,7 @@ for manifest_path in ${RUST}/lib/rustlib/manifest-rust-std-*; do
     cargo miri setup --target=${manifest_path#*/manifest-rust-std-} --verbose
 done
 
-# remove standard library sources again -- we don’t need them any more
-rm -rf ${RUST}/lib/rustlib/src
+# remove standard library -- we don’t need it any more
+rm -rf ${RUST}/lib/rustlib
 
 complete "${RUST}" "rust-miri-${VERSION}" "${OUTPUT}"


### PR DESCRIPTION
Closes https://github.com/compiler-explorer/infra/pull/1630.

See https://github.com/compiler-explorer/infra/pull/1631#issuecomment-2913903162.