### PR TITLE
[miri] ignore targets that can’t be built

### DIFF
--- a/miri/build.sh
+++ b/miri/build.sh
@@ -26,7 +26,7 @@ git pull
 make ce
 popd
 
-/opt/compiler-explorer/infra/bin/ce_install --enable nightly install compilers/rust/newer/nightly nightly
+/opt/compiler-explorer/infra/bin/ce_install --enable nightly install "compilers/rust/newer/nightly nightly"
 
 RUST=/opt/compiler-explorer/rust-miri-${VERSION}
 
@@ -46,7 +46,8 @@ rustup default miri
 export MIRI_SYSROOT=${RUST}/miri-sysroot
 
 for manifest_path in ${RUST}/lib/rustlib/manifest-rust-std-*; do
-    cargo miri setup --target=${manifest_path#*/manifest-rust-std-} --verbose
+    # some targets can’t be built -- ignore those
+    cargo miri setup --target=${manifest_path#*/manifest-rust-std-} --verbose || true
 done
 
 # remove standard library -- we don’t need it any more


### PR DESCRIPTION
There are some targets for which standard libraries are installed on CE, but these targets don’t exist (any more), e. g. `armv7-apple-ios` (that target was [removed in 2023](https://blog.rust-lang.org/2023/09/25/Increasing-Apple-Version-Requirements/)).

This happens when a target is removed, but `ce_install` still installs an old `nightly` tarball, which `miri/build.sh` then picks up.

I ran the build locally and it builds for me:
```
[...]
+ echo ce-build-status:OK
ce-build-status:OK
```