### PR TITLE
micropython: hardcode _PACKAGE_INDEX value for robust patching

### DIFF
--- a/micropython/patches/mip-offline.patch
+++ b/micropython/patches/mip-offline.patch
@@ -8,7 +8,7 @@
 +        return cls(url)
 +    def __init__(self, url):
 +        import sys
-+        path = url.replace(_PACKAGE_INDEX, sys.executable.replace("bin/micropython", "mip"))
++        path = url.replace("https://micropython.org/pi/v2", sys.executable.replace("bin/micropython", "mip"))
 +        try:
 +            self.raw = open(path, "rb")
 +            self.status_code = 200


### PR DESCRIPTION
MicroPython has a concept of "parser constants", i.e. values that aren't real variables but just substitutions made while parsing the python source. `_PACKAGE_INDEX` is, in some versions that this mip patch needs to apply to, a parser constant that's only defined after the import statement it's patching against, leading to an error when attempting to use the patch package manager.