### PR TITLE
Add ArchieSDK (Acorn Archimedes GCC 8.5.0 cross-compiler)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         image:
+        - archiesdk
         - ccc
         - compcert
         - clad

--- a/Dockerfile.archiesdk
+++ b/Dockerfile.archiesdk
@@ -1,0 +1,20 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y -q && apt-get upgrade -y -q && \
+    apt-get install -y -q \
+    bison \
+    build-essential \
+    ca-certificates \
+    curl \
+    flex \
+    git \
+    texinfo \
+    wget \
+    xz-utils
+
+RUN mkdir -p /root
+COPY archiesdk /root/
+COPY common.sh /root/
+
+WORKDIR /root

--- a/archiesdk/build.sh
+++ b/archiesdk/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -ex
+source common.sh
+
+VERSION=$1
+LAST_REVISION="${3:-}"
+
+REVISION="archiesdk-gcc-${VERSION}"
+FULLNAME="${REVISION}.tar.xz"
+OUTPUT="$2/${FULLNAME}"
+
+REPO=/tmp/archiesdk
+DEST="/opt/compiler-explorer/${REVISION}"
+
+initialise "${REVISION}" "${OUTPUT}" "${LAST_REVISION}"
+
+git clone --depth 1 https://gitlab.com/_targz/archiesdk.git "${REPO}"
+
+cd "${REPO}"
+
+# Build just the GCC cross-compiler (not the full SDK libraries)
+./build.sh gcc
+
+# The built compiler ends up in tools/bin/ within the SDK
+mkdir -p "${DEST}/bin"
+
+# Copy the cross-compiler toolchain binaries
+cp tools/bin/arm-archie-* "${DEST}/bin/"
+
+# Copy any support libraries the compiler needs (libgcc etc.)
+if [ -d tools/lib ]; then
+    cp -r tools/lib "${DEST}/"
+fi
+if [ -d tools/libexec ]; then
+    cp -r tools/libexec "${DEST}/"
+fi
+
+# Copy the target-specific headers and libraries needed for compilation
+if [ -d tools/arm-archie ]; then
+    cp -r tools/arm-archie "${DEST}/"
+fi
+
+complete "${DEST}" "${REVISION}" "${OUTPUT}"

--- a/archiesdk/build.sh
+++ b/archiesdk/build.sh
@@ -1,44 +1,105 @@
 #!/bin/bash
 
+## $1 : version (e.g. "Release-1")
+## $2 : destination directory
+## $3 : last revision successfully built
+
 set -ex
 source common.sh
 
-VERSION=$1
+VERSION="${1}"
 LAST_REVISION="${3:-}"
 
-REVISION="archiesdk-gcc-${VERSION}"
-FULLNAME="${REVISION}.tar.xz"
-OUTPUT="$2/${FULLNAME}"
+GCC_URL="https://gitlab.com/_targz/gcc.git"
+BINUTILS_URL="https://gitlab.com/_targz/binutils.git"
+SDK_URL="https://gitlab.com/_targz/archiesdk.git"
 
-REPO=/tmp/archiesdk
-DEST="/opt/compiler-explorer/${REVISION}"
+GCC_REVISION=$(get_remote_revision "${GCC_URL}" "heads/master")
+BINUTILS_REVISION=$(get_remote_revision "${BINUTILS_URL}" "heads/master")
+SDK_REVISION=$(get_remote_revision "${SDK_URL}" "tags/${VERSION}")
+
+# Revision captures all three upstream sources
+REVISION="${VERSION}-gcc${GCC_REVISION:0:8}-bi${BINUTILS_REVISION:0:8}-sdk${SDK_REVISION:0:8}"
+
+FULLNAME="archiesdk-${VERSION}"
+OUTPUT=$(realpath "$2/${FULLNAME}.tar.xz")
 
 initialise "${REVISION}" "${OUTPUT}" "${LAST_REVISION}"
 
-git clone --depth 1 https://gitlab.com/_targz/archiesdk.git "${REPO}"
+# Build to the final CE install path so the sysroot baked into GCC is correct at runtime
+INSTALL_PREFIX="/opt/compiler-explorer/archiesdk/${VERSION}"
+SYSROOT="${INSTALL_PREFIX}/SDK"
+mkdir -p "${SYSROOT}/include" "${SYSROOT}/lib"
 
-cd "${REPO}"
+NCPU=$(nproc)
 
-# Build just the GCC cross-compiler (not the full SDK libraries)
-./build.sh gcc
+# Clone archiesdk at the tagged version
+git clone --depth 1 --branch "${VERSION}" "${SDK_URL}" archiesdk-src
+ARCHIESDK=$(realpath archiesdk-src)
 
-# The built compiler ends up in tools/bin/ within the SDK
-mkdir -p "${DEST}/bin"
+# Install SDK headers into the sysroot
+cp -r "${ARCHIESDK}/SDK/include/." "${SYSROOT}/include/"
 
-# Copy the cross-compiler toolchain binaries
-cp tools/bin/arm-archie-* "${DEST}/bin/"
+# Clone binutils and GCC from master
+git clone --depth 1 "${BINUTILS_URL}" binutils-src
+git clone --depth 1 "${GCC_URL}" gcc-src
 
-# Copy any support libraries the compiler needs (libgcc etc.)
-if [ -d tools/lib ]; then
-    cp -r tools/lib "${DEST}/"
-fi
-if [ -d tools/libexec ]; then
-    cp -r tools/libexec "${DEST}/"
-fi
+# Fetch GCC build prerequisites (gmp, mpc, mpfr, isl)
+cd gcc-src
+./contrib/download_prerequisites
+cd ..
 
-# Copy the target-specific headers and libraries needed for compilation
-if [ -d tools/arm-archie ]; then
-    cp -r tools/arm-archie "${DEST}/"
-fi
+# Build binutils
+mkdir -p build-binutils
+cd build-binutils
+../binutils-src/configure \
+    --prefix="${INSTALL_PREFIX}" \
+    --target=arm-archie \
+    --with-sysroot="${SYSROOT}" \
+    --with-build-sysroot="${SYSROOT}" \
+    --disable-nls \
+    --disable-multilib
+make -j"${NCPU}" configure-host
+make -j"${NCPU}"
+make install
+cd ..
 
-complete "${DEST}" "${REVISION}" "${OUTPUT}"
+# Build GCC cross-compiler + libgcc
+mkdir -p build-gcc
+cd build-gcc
+../gcc-src/configure \
+    --prefix="${INSTALL_PREFIX}" \
+    --target=arm-archie \
+    --with-sysroot="${SYSROOT}" \
+    --with-build-sysroot="${SYSROOT}" \
+    --disable-nls \
+    --disable-shared \
+    --enable-languages=c \
+    --disable-multilib \
+    --disable-threads \
+    --disable-decimal-float \
+    --disable-libgomp \
+    --disable-libmudflap \
+    --disable-libssp \
+    --disable-libatomic \
+    --disable-libquadmath \
+    --with-cpu=arm2 \
+    --with-float=soft
+make -j"${NCPU}" all-gcc all-target-libgcc \
+    CFLAGS_FOR_TARGET='-msoft-float -mcpu=arm2 -mno-thumb-interwork -O2 -ffreestanding'
+make install-gcc install-target-libgcc
+cd ..
+
+# Build SDK libraries (libc.a, libm.a, libarchie.a, crt0.o, crtheap.o)
+# Override tool paths to use our freshly built cross-compiler
+cd "${ARCHIESDK}/SDK"
+make sdk \
+    ARCHIESDK="${ARCHIESDK}" \
+    ARCHIECC="${INSTALL_PREFIX}/bin/arm-archie-gcc" \
+    ARCHIEAS="${INSTALL_PREFIX}/bin/arm-archie-as" \
+    ARCHIEAR="${INSTALL_PREFIX}/bin/arm-archie-ar" \
+    ARCHIEOBJCOPY="${INSTALL_PREFIX}/bin/arm-archie-objcopy"
+cp lib/*.a lib/*.o "${SYSROOT}/lib/"
+cd -
+
+complete "${INSTALL_PREFIX}" "${FULLNAME}" "${OUTPUT}"


### PR DESCRIPTION
*(I'm Molty, an AI assistant acting on behalf of @mattgodbolt)*

Adds build support for [ArchieSDK](https://gitlab.com/_targz/archiesdk) — a GCC 8.5.0 cross-compiler targeting the Acorn Archimedes (RISC OS/Arthur, ARMv2/ARM2, soft-float).

## What this adds

- `Dockerfile.archiesdk` — Ubuntu 22.04 with GCC build deps (bison, flex, texinfo, etc.)
- `archiesdk/build.sh` — builds the full toolchain from source:
  1. Clones `_targz/archiesdk` at `Release-1`, plus `_targz/gcc` and `_targz/binutils` from master
  2. Fetches GCC prerequisites (gmp/mpfr/mpc/isl via `download_prerequisites`)
  3. Builds binutils and GCC 8.5.0 for the `arm-archie` target
  4. Builds the SDK libraries (libc.a, libm.a, libarchie.a, crt0.o, crtheap.o) into the sysroot
  5. Packages everything as a tar.xz

## Design notes

- The install prefix is baked as `/opt/compiler-explorer/archiesdk/Release-1` at build time so GCC's sysroot pointer is correct at runtime on CE nodes
- Revision string captures all three upstream repos (sdk + gcc + binutils) for proper skip detection
- C-only compiler (GCC 8.5.0 is the last version to support ARMv2)

Closes compiler-explorer/compiler-explorer#7982 (once infra + CE config follow)
