### PR TITLE
Install `libgccjit.so` into correct location

### DIFF
--- a/rust-cg-gcc/build.sh
+++ b/rust-cg-gcc/build.sh
@@ -151,7 +151,9 @@ mkdir -p toolroot
 mv rustup/toolchains/*/* toolroot/
 
 # libgccjit
-mv $PREFIX/lib/libgccjit.so* toolroot/lib
+libgccjit_dir=toolroot/lib/rustlib/x86_64-unknown-linux-gnu/codegen-backends/lib/x86_64-unknown-linux-gnu
+mkdir -p $libgccjit_dir
+mv $PREFIX/lib/libgccjit.so* $libgccjit_dir
 
 # cg_gcc backend
 mv ./rustc_codegen_gcc/target/release/librustc_codegen_gcc.so toolroot/lib


### PR DESCRIPTION
The location that `rustc-cg-gcc` expects its `libgccjit.so` in was moved recently in https://github.com/rust-lang/rust/commit/c0d4f5fab1104ef8b96750352917e018d0d99e04.