### PR TITLE
[WIP] Issue #131 — [feature] add lua support to misc-builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         - hylo
         - iwyu
         - lc3
+        - lua
         - misc
         - nasm
         - ncc-ng

--- a/Dockerfile.lua
+++ b/Dockerfile.lua
@@ -1,0 +1,16 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
+    apt install -y -q \
+    build-essential \
+    curl \
+    xz-utils \
+    && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /root
+COPY lua /root/
+COPY common.sh /root/
+
+WORKDIR /root

--- a/lua/build.sh
+++ b/lua/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -ex
+source common.sh
+
+VERSION=$1
+
+URL=https://www.lua.org/ftp/lua-${VERSION}.tar.gz
+
+FULLNAME=lua-${VERSION}
+OUTPUT=$2/${FULLNAME}.tar.xz
+
+REVISION="lua-${VERSION}"
+LAST_REVISION="${3:-}"
+
+initialise "${REVISION}" "${OUTPUT}" "${LAST_REVISION}"
+
+STAGING_DIR=/opt/compiler-explorer/${FULLNAME}
+rm -rf "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}"
+
+BUILD_DIR=$(pwd)/build
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+curl -sL "${URL}" | tar zxf - --strip-components 1
+
+# posix is supported by every released Lua version and avoids the readline
+# dependency of the linux target; lua/luac are still fully functional.
+make -j"$(nproc)" posix
+make INSTALL_TOP="${STAGING_DIR}" install
+
+# Sanity-check the built binaries.
+"${STAGING_DIR}/bin/lua" -v
+"${STAGING_DIR}/bin/luac" -v
+
+complete "${STAGING_DIR}" "${FULLNAME}" "${OUTPUT}"


### PR DESCRIPTION
Automated attempt by @leftibot. Opening as **draft** — verification failed.

**Reason:** no test files were detected in the diff

### What changed

> Fix #131: add Lua support to misc-builder
> Adds Dockerfile.lua and lua/build.sh so misc-builder can produce
> PUC-Rio Lua tarballs for Compiler Explorer, coordinating with
> compiler-explorer/compiler-explorer#8696 and compiler-explorer/infra#2117.
> The build script downloads the released tarball from www.lua.org,
> builds with the `posix` target (supported across 5.1.5 through 5.5.0,
> no readline dependency), installs into a staged prefix, and packages
> the result as lua-<version>.tar.xz containing bin/lua and bin/luac.
> The new image is also wired into the GitHub Actions build matrix.
> Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

### Files
```
 .github/workflows/build.yml |  1 +
 Dockerfile.lua              | 16 ++++++++++++++++
 lua/build.sh                | 37 +++++++++++++++++++++++++++++++++++++
 3 files changed, 54 insertions(+)
```

Will close #131 once finalized.

_Triggered by @lefticus._