### PR TITLE
aburi: install x86_64 cmake, not aarch64

### DIFF
--- a/Dockerfile.aburi
+++ b/Dockerfile.aburi
@@ -20,7 +20,7 @@ RUN apt-get install -y -q software-properties-common && \
     add-apt-repository -y "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-18 main" && \
     apt update -y -q && \
     apt install -y -q llvm-18-dev llvm-18 && \
-    wget -qO- https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-aarch64.tar.gz | tar zx -C /usr --strip-components=1
+    wget -qO- https://github.com/Kitware/CMake/releases/download/v4.1.0/cmake-4.1.0-linux-x86_64.tar.gz | tar zx -C /usr --strip-components=1
 
 RUN mkdir -p /root
 COPY aburi /root/


### PR DESCRIPTION
`Dockerfile.aburi` (added in #136) fetches the **aarch64** cmake tarball:

```dockerfile
wget -qO- .../cmake-4.1.0-linux-aarch64.tar.gz | tar zx -C /usr --strip-components=1
```

…but the builder is built on the `build-x86_64` matrix and the aburi artifact is produced on CE's **x86_64** self-hosted `bespoke-build` runners. The image build itself passes (it only untars the binary), but the actual aburi build fails when `cmake` can't exec (exec-format error). Switch to `cmake-4.1.0-linux-x86_64.tar.gz`.

Ref compiler-explorer/compiler-explorer#8871. Needed before the aburi S3 artifact can be built for infra#2202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)