### PR TITLE
aburi: auto-detect newest macOS SDK, install to stable path

### DIFF
--- a/aburi/build.sh
+++ b/aburi/build.sh
@@ -18,7 +18,6 @@ URL="https://github.com/serjective/aburi.git"
 BRANCH="atta-mills"
 SDK_REPO="https://github.com/alexey-lysiuk/macos-sdk.git"
 SDK_BRANCH="heads/main"
-SDK_SDK="MacOSX26.4.sdk"
 
 ABURI_REVISION=$(get_remote_revision "${URL}" "heads/${BRANCH}")
 SDK_REVISION=$(get_remote_revision "${SDK_REPO}" "${SDK_BRANCH}")
@@ -31,15 +30,24 @@ git clone --depth 1 "${URL}" --branch "${BRANCH}" aburi-source
 cmake -S aburi-source -B aburi-source/build -DCMAKE_BUILD_TYPE=Release -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
 cmake --build aburi-source/build -j"$(nproc)"
 
-# Fetch macOS SDK headers
+# Fetch macOS SDK headers. Pick the newest MacOSX*.sdk the repo currently ships
+# rather than pinning a version: upstream rolls forward (e.g. 26.4 -> 26.5) and a
+# hardcoded name silently breaks this build the moment it's removed.
 git clone --depth 1 --filter=blob:none --sparse "${SDK_REPO}" macos-sdk-repo
+SDK_SDK=$(git -C macos-sdk-repo ls-tree -d --name-only HEAD | grep -E '^MacOSX[0-9.]+\.sdk$' | sort -V | tail -1)
+if [[ -z "${SDK_SDK}" ]]; then
+    echo "No MacOSX*.sdk directory found in ${SDK_REPO}" >&2
+    exit 1
+fi
+echo "Using macOS SDK: ${SDK_SDK}"
 git -C macos-sdk-repo sparse-checkout set "${SDK_SDK}/usr/include"
 
-# Stage
+# Stage. Install the SDK to a fixed, version-independent path (macos-sdk/) so the
+# compiler's --sysroot never changes when the SDK version rolls forward.
 STAGING_DIR="${PWD}/stage"
 mkdir -p "${STAGING_DIR}/bin"
 mkdir -p "${STAGING_DIR}/macos-sdk"
 cp aburi-source/build/aburi "${STAGING_DIR}/bin/"
-cp -a "macos-sdk-repo/${SDK_SDK}" "${STAGING_DIR}/macos-sdk/"
+cp -a "macos-sdk-repo/${SDK_SDK}/." "${STAGING_DIR}/macos-sdk/"
 
 complete "${STAGING_DIR}" "${FULLNAME}" "${OUTPUT}"


### PR DESCRIPTION
Makes the aburi build robust to macOS SDK version rolls, and unblocks the build (it currently fails even though aburi compiles cleanly).

### Problem
`build.sh` hardcoded `SDK_SDK="MacOSX26.4.sdk"`, but the upstream [alexey-lysiuk/macos-sdk](https://github.com/alexey-lysiuk/macos-sdk) repo rolls forward — it now ships **`MacOSX26.5.sdk`** and 26.4 is gone. So the build dies at:
```
cp: cannot stat 'macos-sdk-repo/MacOSX26.4.sdk': No such file or directory
```
(aburi itself builds to 100% first — this is purely the SDK staging step.)

### Change
- **Auto-detect** the newest `MacOSX*.sdk` the repo currently ships (`ls-tree … | sort -V | tail -1`), erroring clearly if none is found — no more pinned version to go stale.
- **Stage to a fixed, version-independent path** (`macos-sdk/`) instead of a versioned subdir, so the compiler's `--sysroot` never has to change when the SDK rolls forward.

### Follow-up (properties)
compiler-explorer/compiler-explorer#8872 must update its `--sysroot` to the stable path (dropping the versioned subdir):
```
--sysroot=/opt/compiler-explorer/aburi/atta-mills/macos-sdk
```
I'll flag that on #8872.

Ref compiler-explorer/compiler-explorer#8871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)