### PR TITLE
clad: generate LLVM's tablegen headers for LLVM 22

### DIFF
--- a/clad/build.sh
+++ b/clad/build.sh
@@ -59,6 +59,13 @@ cmake "${LLVM}/llvm" \
     -GNinja
 
 ninja clang-headers
+# LLVM 22 made llvm/Analysis/TargetLibraryInfo.inc a tablegen-generated header, produced by
+# the analysis_gen target. Clad's targets don't depend on it, and we deliberately never
+# build LLVM proper here, so nothing else generates it. Guard on the .td rather than on the
+# LLVM version so this stays correct if the rule moves again.
+if [[ -f "${LLVM}/llvm/include/llvm/Analysis/TargetLibraryInfo.td" ]]; then
+    ninja analysis_gen
+fi
 ninja clad
 ninja install-clad
 cp -r "${SOURCE}/include" "${PREFIX}"


### PR DESCRIPTION
Building clad 2.4 against LLVM 22.1.0 fails:

```
/root/llvm/llvm/include/llvm/Analysis/TargetLibraryInfo.h:75:10: fatal error:
llvm/Analysis/TargetLibraryInfo.inc: No such file or directory
   75 | #include "llvm/Analysis/TargetLibraryInfo.inc"
compilation terminated.
```

(https://github.com/compiler-explorer/infra/actions/runs/31059798933)

LLVM 22 made that header tablegen-generated. `llvm/include/llvm/Analysis/CMakeLists.txt` at `llvmorg-22.1.0` is now:

```cmake
set(LLVM_TARGET_DEFINITIONS TargetLibraryInfo.td)
tablegen(LLVM TargetLibraryInfo.inc -gen-target-library-info)
add_public_tablegen_target(analysis_gen)
```

The file does not exist at all in LLVM 21, which is why clad 2.3 against 21.1.0 built fine in the same batch.

We deliberately build only `clang-headers` and `clad` rather than LLVM itself, since the plugin is a loadable module that resolves LLVM symbols at load time. That is what keeps a clad build at five minutes instead of hours, and it is worth keeping. But it means nothing runs `analysis_gen`, because clad's own targets do not depend on it, and the compile of `ClangBackendPlugin.cpp` fails as soon as it reaches `PassBuilder.h`.

So: build `analysis_gen` where it exists. The guard is on the `.td` file rather than on `${CLANG_VERSION}` because the `.td` is the thing that creates the target, so the test matches the real condition and self-corrects if upstream moves the rule again.

This is the first missing generated header, and the build stops at the first error, so I cannot promise it is the only one. If another `.inc` turns up in the rebuild we add it the same way.

Arguably the real bug is upstream: when clad is configured through `LLVM_EXTERNAL_PROJECTS`, its CMake could depend on the tablegen targets itself rather than relying on the caller to have built LLVM first.

Needed by compiler-explorer/infra#2264 and compiler-explorer/compiler-explorer#8990, which add clad 2.3 and 2.4. 2.3 is built and installed already; 2.4 needs this, then an image rebuild, then a fresh `bespoke-build`.

cc @Vedant2005goyal @vgvassilev

🤖 Generated with [Claude Code](https://claude.com/claude-code)
