### PR TITLE
aburi: fold the two apt layers into one

### DIFF
--- a/Dockerfile.aburi
+++ b/Dockerfile.aburi
@@ -15,9 +15,6 @@ RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
     xz-utils \
     zlib1g-dev
 
-# Refresh the index in this layer: the update above sits in a separate, cachable
-# layer, so once it is cached these installs resolve against a stale index and
-# 404 as soon as a package (systemd, here) rolls forward on the mirror.
 RUN apt-get update -y -q && \
     apt-get install -y -q software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc && \

--- a/Dockerfile.aburi
+++ b/Dockerfile.aburi
@@ -11,12 +11,10 @@ RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
     libxml2-dev \
     libzstd-dev \
     lsb-release \
+    software-properties-common \
     wget \
     xz-utils \
-    zlib1g-dev
-
-RUN apt-get update -y -q && \
-    apt-get install -y -q software-properties-common && \
+    zlib1g-dev && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc && \
     add-apt-repository -y "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-22 main" && \
     apt update -y -q && \

--- a/Dockerfile.aburi
+++ b/Dockerfile.aburi
@@ -15,7 +15,11 @@ RUN apt update -y -q && apt upgrade -y -q && apt update -y -q && \
     xz-utils \
     zlib1g-dev
 
-RUN apt-get install -y -q software-properties-common && \
+# Refresh the index in this layer: the update above sits in a separate, cachable
+# layer, so once it is cached these installs resolve against a stale index and
+# 404 as soon as a package (systemd, here) rolls forward on the mirror.
+RUN apt-get update -y -q && \
+    apt-get install -y -q software-properties-common && \
     wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc && \
     add-apt-repository -y "deb https://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-22 main" && \
     apt update -y -q && \


### PR DESCRIPTION
Fixes the red push-to-main build after #142.

## What broke

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/s/systemd/systemd_249.11-0ubuntu3.21_amd64.deb  404  Not Found
```

`Dockerfile.aburi` had two apt layers: one that updated and installed the base packages, and a second that installed `software-properties-common` without an update of its own. #142 edited the second layer, which invalidated it while the first stayed cached, so the installs ran against an index from whenever that cached layer was last built. It still named `systemd 249.11-0ubuntu3.21`, which the mirror had since superseded and removed.

Not a mirror outage: every other image in [that run](https://github.com/compiler-explorer/misc-builder/actions/runs/31757362141) built fine, and a re-run failed identically.

## The change

Fold the two layers into one, so there is a single apt layer. `software-properties-common` joins the base install list, and the only remaining second `update` is the one `add-apt-repository` genuinely requires in order to see the LLVM source it has just added.

Worth being straight about the limits of this: it resolves the immediate breakage because the merged layer refetches the index, not because it makes the build reproducible. Anything that causes a refetch would clear the error equally well. The underlying issue is that the build depends on a mutable upstream index, and that is worth addressing separately — pinning the base image by digest, a snapshot mirror, or dropping `/var/lib/apt/lists/*` so a stale index can never be silently inherited.

## Testing

`docker build --no-cache -f Dockerfile.aburi` succeeds and the image has what the build needs:

```
Ubuntu clang version 22.1.8
/usr/lib/llvm-22/lib/cmake/llvm            (LLVM_DIR)
/usr/lib/x86_64-linux-gnu/libc++abi.so     (shipped beside Adinkra)
cmake version 4.1.0
```

`--no-cache` rebuilds everything, so it can't reproduce the stale-index condition itself. The CI build on merge is the real check.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)