### PR TITLE
vast: set $ORIGIN rpath on the executables too

### DIFF
--- a/vast/build.sh
+++ b/vast/build.sh
@@ -49,5 +49,10 @@ cmake --install ./builds/compiler-explorer --prefix "$STAGING_DIR"
 # This code copied and modified from compiler-explorer/cobol-builder/build/build.sh
 cp $(ldd "${STAGING_DIR}/bin/vast-front" | grep -E  '=> /' | grep -Ev 'lib(pthread|c|dl|rt).so' | awk '{print $3}') "${STAGING_DIR}/lib"
 patchelf --set-rpath '$ORIGIN/../lib' $(find ${STAGING_DIR}/lib/ -name \*.so\*)
+# ...and the executables themselves. vast's own install writes them a RUNPATH of the
+# literal "/../lib": the $ORIGIN has been expanded away before it is written, so they
+# cannot see the libraries staged above and fail to start with "libclang-cpp.so.19.1:
+# cannot open shared object file". See compiler-explorer/misc-builder#102.
+patchelf --set-rpath '$ORIGIN/../lib' "${STAGING_DIR}"/bin/*
 
 complete "${STAGING_DIR}" "vast-${VERSION}" "${OUTPUT}"


### PR DESCRIPTION
Fixes #102, which has had vast's install disabled since January 2025:

```
vast-front: error while loading shared libraries: libclang-cpp.so.19.1:
cannot open shared object file: No such file or directory
```

## The diagnosis

It isn't a missing library. **Every library vast needs is already in the tarball** — `lib/libclang-cpp.so.19.1` is right there. The problem is only where the binaries look:

```
bin/vast-front      RUNPATH: [/../lib]            <- $ORIGIN expanded away
lib/libxml2.so.2    RUNPATH: [$ORIGIN/../lib]     <- correct
```

`build.sh` stages the dependencies into `lib/` and patches the rpath of **the libraries**, but never of the executables. Their RUNPATH comes from vast's own install as a literal `/../lib` — the classic signature of `$ORIGIN` being expanded to nothing before it's written — which resolves to `/lib` and so never finds the staged directory.

## The fix

One extra `patchelf` line covering `bin/*`. All six binaries there are ELF, so nothing gets patched that shouldn't.

I deliberately did **not** widen the dependency collection (still `ldd` of `vast-front` only): the test below shows all six binaries run using just what `lib/` already contains, so the collection is already sufficient and the rpath was the only fault.

## Verified

Against the current published artifact `vast-trunk-20260215`, in a clean `ubuntu:22.04` container with no LLVM installed and no `LD_LIBRARY_PATH`:

```
--- before ---
vast-front: error while loading shared libraries: libclang-cpp.so.19.1: cannot open shared object file

--- after patchelf --set-rpath '$ORIGIN/../lib' bin/* ---
RUNPATH: [$ORIGIN/../lib]
vast-front --version -> Ubuntu clang version 19.1.7
                        Target: x86_64-pc-linux-gnu

vast-detect-parsers OK   vast-front OK   vast-lsp-server OK
vast-opt OK              vast-query OK   vast-repl OK
```

I also confirmed the isolation independently: without `LD_LIBRARY_PATH` the binary has 2 unresolved deps; pointing it at the shipped `lib/` gives 0.

## After this merges

The builder image needs to rebuild (build scripts are baked in), then a build produces a fixed artifact. At that point compiler-explorer/infra#2296 can have vast's `if: daily-but-archived` put back to `if: nightly` — it's currently listed-but-not-installed purely so the S3 pruner doesn't treat its tarballs as unowned.

Worth noting vast's daily build is still wired up in compiler-workflows and merely gated on upstream activity, so nothing else needs re-enabling.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)