### PR TITLE
Use PAHOLE_REVISION, not JAKT_REVISION, in pahole's build revision

### DIFF
--- a/misc/build-pahole.sh
+++ b/misc/build-pahole.sh
@@ -39,7 +39,7 @@ else
 fi
 
 PAHOLE_REVISION=$(git ls-remote --heads ${URL} refs/heads/${BRANCH} | cut -f 1)
-REVISION="pahole-${JAKT_REVISION}-elfutils-${ELFUTILS_VERSION}"
+REVISION="pahole-${PAHOLE_REVISION}-elfutils-${ELFUTILS_VERSION}"
 
 echo "ce-build-revision:${REVISION}"
 echo "ce-build-output:${OUTPUT}"


### PR DESCRIPTION
`misc/build-pahole.sh` was cloned from `jakt/build.sh`, and the rename stopped one line short:

```bash
PAHOLE_REVISION=$(git ls-remote --heads ${URL} refs/heads/${BRANCH} | cut -f 1)
REVISION="pahole-${JAKT_REVISION}-elfutils-${ELFUTILS_VERSION}"
```

`JAKT_REVISION` is only ever assigned in `jakt/build.sh`, so here it expands to nothing and the freshly-fetched sha is discarded. `REVISION` is therefore a constant -- which is exactly what is parked in S3 right now:

```
$ curl -sf https://compiler-explorer.s3.amazonaws.com/opt/.buildrevs/pahole
pahole--elfutils-0.188
```

`daily-build/action.yml` passes the stored revision as `$3`, so `[[ "${REVISION}" == "${LAST_REVISION}" ]]` matches every night, the script prints `ce-build-status:SKIPPED`, and every subsequent step is gated on `status != 'SKIPPED'`. The daily workflow in compiler-workflows has reported success since December 2022 without producing a build: until today the only artifact in S3 was `pahole-trunk-20221216.tar.xz`. The bespoke workflow passes no `$3`, which is why manual runs still built -- that is how `pahole-trunk-20260817.tar.xz` (v1.31) got made.

With the real sha interpolated, the computed revision no longer matches the stored constant, so the next nightly builds and writes a usable revision. De-duplication still works -- verified all three paths against the fixed script:

| stored `$3` | result |
| --- | --- |
| empty | `revision:pahole-56ef6fa...-elfutils-0.188`, builds |
| `pahole--elfutils-0.188` (today's stale value) | builds |
| equal to the computed revision | `SKIPPED` |

I swept every `*.sh` in the repo for other `REVISION=` assignments interpolating a variable the same file never assigns; this was the only one. `shellcheck` is clean on the changed file.
